### PR TITLE
install.sh updates, fixes and additions

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -3,11 +3,12 @@
 
 # Read in settings
 source_path=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
-source "$source_path/settings"
+. "$source_path/settings"
 
 
+display_help_text () {
 
-read -r -d '' help_text <<-'EOF'
+  cat <<-'EOF'
 install.sh version 0.5
 
 Run from a dotfile directory, links all files and directories into the current
@@ -40,12 +41,13 @@ user's home directory
                     (default is current directory)
   destination dir : Where to put symlinks
                     (default is '~')
-EOF
 
+EOF
+}
 
 # functions
 
-function list_contains() {
+list_contains() {
   for word in $1; do
     [ "$word" = "$2" ] && return 0
   done
@@ -60,7 +62,7 @@ remove_dupes() {
   echo "$new_list"
 }
 
-function remove_file() {
+remove_file() {
   if [ "$testing" = true ]; then
     echo "TESTING: rm -rf $1"
   elif [ "$force" = true ]; then
@@ -72,7 +74,7 @@ function remove_file() {
   fi
 }
 
-function link_file() {
+link_file() {
   if [ "$testing" = true ]; then
     echo "TESTING: ln -s $1 $2"
   else
@@ -81,7 +83,7 @@ function link_file() {
   fi
 }
 
-function copy_file() {
+copy_file() {
   if [ "$testing" = true ]; then
     echo "TESTING: cp -R $1 $2"
   else
@@ -90,7 +92,7 @@ function copy_file() {
   fi
 }
 
-function make_dir() {
+make_dir() {
   if [ "$testing" = true ]; then
     echo "TESTING: mkdir -p $1"
   else
@@ -117,11 +119,11 @@ for arg in $@; do
       ;;
     -c|--config-file)
       shift
-      source $1
+      . $1
       shift
       ;;
     -h|--help)
-      echo "$help_text"
+      display_help_text
       exit
       ;;
   esac
@@ -150,7 +152,7 @@ link_children_sources=$(remove_dupes "$link_children_sources" "$ignore_sources")
 # Do it
 
 # Create links
-function make_links() {
+make_links() {
   for s in $1; do
     target="$dest_dir/.$s"
     src="$source_dir/$s"

--- a/install.sh
+++ b/install.sh
@@ -11,35 +11,37 @@ display_help_text () {
   cat <<-'EOF'
 install.sh version 0.5
 
-Run from a dotfile directory, links all files and directories into the current
-user's home directory
+Copies/links files and directories from the current dir to the user's home dir
 
-./install.sh [-f] [-h] [-t] [-c config-file] [source dir] [destination dir]
+USAGE: install.sh [OPTIONS] [SOURCE-DIR] [DEST-DIR]
+    SOURCE-DIR defaults to the current directory
+    DEST-DIR defaults to the current user's home directory
 
-  -f (--force)    : Overwrite any files / directories in the destination dir
+OPTIONS:
+  -f (--force)    : force overwrite of files or directories in DEST-DIR
                     (default is false)
-  -h (--help)     : This help message
-  -t (--test)     : Don't actually do anything, just show what would be done
+  -h (--help)     : display this help and exit
+  -t (--test)     : test mode - only display changes, don't make them
                     (default is false)
-  -c (--config)   : Specify configuration file. Example file contents:
-                    # Settings
-                    # (you can use globs)
-                    # list of files to link
-                    link='*'
-                    # ignore these files (modifies include)
-                    ignore='Icon* *.md *.sh *.txt scripts'
-                    # just copy these files
-                    copy=''
-                    # create directory itself (not contents), then link the
-                    # children of the directory
-                    link_children='config'
-                    (defaults are in `install.sh`)
+  -c (--config)   : specify a configuration file
+                    (default configuration file is `settings`)
+                      Example config file contents:
+                        # Settings (can use globs)
+                        # ignore these files (modifies include)
+                        ignore='Icon* *.md *.sh *.txt scripts'
+                        # create dir (not contents), then sym-link children (contents)
+                        link_children='config'
+                        # copy these files
+                        copy=''
+                        # sym-link these files
+                        link='*'
 
-  source dir      : Contains dotfiles. They are expected to NOT have leading
-                    '.' For example, if the dotfile is '.bashrc' then in the
-                    source dir it is 'bashrc'
+  SOURCE-DIR      : directory containing dotfiles to be copied and/or linked
                     (default is current directory)
-  destination dir : Where to put symlinks
+                      files should NOT have leading '.'
+                      example: '.bashrc' should be named 'bashrc' in SOURCE-DIR
+
+  DEST-DIR        : target directory where copies and links will be placed
                     (default is '~')
 
 EOF

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,10 @@
 #!/bin/sh
 # Run from a dotfile directory, links all files and directories into the current user's home directory
 
+scriptname="install.sh"
+scriptbuildnum="0.6"
+scriptbuilddate="2016-02-01"
+
 ### VARS INITS
 
 # Read in settings
@@ -20,10 +24,15 @@ testing=false
 
 ### FUNCTIONS
 
+display_ver() {
+  echo "$scriptname  ver $scriptbuildnum - $scriptbuilddate"
+}
+
 display_help_text () {
 
+  display_ver   # Print script-title, build-number, and build-date
+
   cat <<-'EOF'
-install.sh version 0.5
 
 Copies/links files and directories from the current dir to the user's home dir
 
@@ -34,7 +43,6 @@ USAGE: install.sh [OPTIONS] [SOURCE-DIR] [DEST-DIR]
 OPTIONS:
   -f (--force)    : force overwrite of files or directories in DEST-DIR
                     (default is false)
-  -h (--help)     : display this help and exit
   -t (--test)     : test mode - only display changes, don't make them
                     (default is false)
   -c (--config)   : specify a configuration file
@@ -49,6 +57,9 @@ OPTIONS:
                         copy=''
                         # sym-link these files
                         link='*'
+
+  -h (--help)     : display this help and exit
+  -V (--version)  : output version information and exit
 
   SOURCE-DIR      : directory containing dotfiles to be copied and/or linked
                     (default is current directory)
@@ -149,6 +160,10 @@ for arg in $@; do
       ;;
     -h|--help)
       display_help_text
+      exit
+      ;;
+    -V|--version)
+      display_ver
       exit
       ;;
   esac

--- a/install.sh
+++ b/install.sh
@@ -166,11 +166,11 @@ make_links "$link_sources"
 
 # Create copies
 for s in $copy_sources; do
-  target="dest_dir/.$s"
+  target="$dest_dir/.$s"
   src="$source_dir/$s"
   # if file (or a link) exists at destination
   if [ -e "$target" ] || [ -L "$target" ]; then
-    remove_file "$target" && link_copy "$src" "$target"
+    remove_file "$target" && copy_file "$src" "$target"
   else
     copy_file "$src" "$target"
   fi


### PR DESCRIPTION
Made the following updates, fixes and additions to install.sh.   Note:  each change was made in a separate commit, and details for each are provided in the commit descriptions.
- fix typos in install.sh code that creates copies.  Specifically, the dest_dir var used without $, and link_copy called instead of copy_file
- corrected cross-platform issues resulting from #!/bin/sh running dash or POSIX-only shells on some systems
- modified Help Text for readability and standardization
- re-Organized script into four sections: var-inits, functions, pre_exec, execution
- added build-number & build-date vars, used in help text display and new '-V | --version' option
